### PR TITLE
Replaced NSError in callback with NSDictionary

### DIFF
--- a/ios/RCTCognito/RCTCognito.m
+++ b/ios/RCTCognito/RCTCognito.m
@@ -64,7 +64,7 @@ RCT_EXPORT_METHOD(syncData: (NSString *)datasetName
   [dataset setString:value forKey:key];
   [[dataset synchronize] continueWithBlock:^id(AWSTask *task) {
     if (task.error) {
-      callback(@[ task.error ]);
+      callback(@[ @{@"code":[NSNumber numberWithLong:task.error.code], @"domain":task.error.domain, @"userInfo":task.error.userInfo, @"localizedDescription":task.error.localizedDescription} ]);
     } else {
       callback(@[ [NSNull null] ]);
     }


### PR DESCRIPTION
Returning an NSError (task.error) in the callback was causing the
following error:
RCTJSONStringify() encountered the following error: Invalid type in
JSON write (NSError) in RCTUtils.m (react-native v0.20.0).  In
react-native 0.18.0 a SIGABT signal was raised.  Since JSON can’t parse
an NSError, the contents of the NSError are first converted to an
NSDictionary which JSONStringify can process correctly.  For
convenience, the localizedDescription is also added to the dictionary
(it’s also usually present in the userInfo.localizedDescription value,
but userInfo can be null)
